### PR TITLE
Add support for xml answers and fix a few env defaults

### DIFF
--- a/environments/longhealth/longhealth.py
+++ b/environments/longhealth/longhealth.py
@@ -19,11 +19,7 @@ from typing import Literal, Optional
 
 import verifiers as vf
 from datasets import Dataset
-from verifiers.utils.data_utils import (
-    BOXED_SYSTEM_PROMPT,
-    THINK_BOXED_SYSTEM_PROMPT,
-    extract_boxed_answer,
-)
+from verifiers.utils.data_utils import BOXED_SYSTEM_PROMPT, THINK_BOXED_SYSTEM_PROMPT, extract_boxed_answer
 
 # Reuse the system prompt from the original LongHealth implementation
 LONGHEALTH_SYSTEM_PROMPT = """

--- a/environments/med_mcqa/med_mcqa.py
+++ b/environments/med_mcqa/med_mcqa.py
@@ -17,20 +17,19 @@ Reference:
   url = {https://github.com/huggingface/lighteval}
 }
 """
-from typing import Any, Dict, Optional
+
+from typing import Any, Dict
 
 import verifiers as vf
 from datasets import load_dataset
-from verifiers.utils.data_utils import (
-    BOXED_SYSTEM_PROMPT,
-    THINK_BOXED_SYSTEM_PROMPT,
-    extract_boxed_answer,
-)
+from medarc_verifiers.prompts import THINK_XML_SYSTEM_PROMPT, XML_SYSTEM_PROMPT, AnswerFormat
+from verifiers.utils.data_utils import BOXED_SYSTEM_PROMPT, THINK_BOXED_SYSTEM_PROMPT, extract_boxed_answer
 
 LETTER_INDICES = ["A", "B", "C", "D"]
 
+
 def med_mcqa(line: Dict[str, Any]) -> Dict[str, Any]:
-    """Build the standard MedMCQA multiple-choice question prompt.""" 
+    """Build the standard MedMCQA multiple-choice question prompt."""
     query = f"Give a letter answer among A, B, C or D.\nQuestion: {line['question']}\n"
     query += "".join(
         [
@@ -39,7 +38,7 @@ def med_mcqa(line: Dict[str, Any]) -> Dict[str, Any]:
         ]
     )
     query += "Answer:"
-    
+
     result = {
         "question": query,
         "answer": LETTER_INDICES[line["cop"] - 1],
@@ -48,6 +47,7 @@ def med_mcqa(line: Dict[str, Any]) -> Dict[str, Any]:
         "instruction": "Give a letter answer among A, B, C or D.\n",
     }
     return result
+
 
 def _get_text_from_completion(completion: Any) -> str:
     """Extract a text string from a model completion."""
@@ -60,7 +60,8 @@ def _get_text_from_completion(completion: Any) -> str:
         return str(last_item)
     return str(completion)
 
-def _first_letter_ad(text: str) -> Optional[str]:
+
+def _first_letter_ad(text: str) -> str | None:
     """Return the first A–D letter found in the text, preferring boxed answers if present."""
     t = text or ""
     boxed_ans = extract_boxed_answer(t)
@@ -73,14 +74,20 @@ def _first_letter_ad(text: str) -> Optional[str]:
             return ch
     return None
 
-def exact_match_reward(completion: Any, answer: Optional[str] = None, **kwargs) -> float:
+
+def exact_match_reward(completion: Any, answer: str | None = None, **kwargs) -> float:
     """Reward 1.0 if the predicted answer matches the correct answer; 0.0 otherwise."""
     text = _get_text_from_completion(completion)
     predicted_ans = _first_letter_ad(text)
     correct_ans = answer.strip().upper() if answer else None
     return float(predicted_ans == correct_ans)
-                 
-def load_environment(use_think: bool = False, system_prompt: Optional[str] = None) -> vf.Environment:
+
+
+def load_environment(
+    use_think: bool = False,
+    system_prompt: str | None = None,
+    answer_format: AnswerFormat | str = AnswerFormat.XML,
+) -> vf.Environment:
     """
     Load the MedMCQA environment with train and validation splits.
     Supports reasoning (use_think=True) or standard evaluation.
@@ -89,7 +96,7 @@ def load_environment(use_think: bool = False, system_prompt: Optional[str] = Non
     train_ds = load_dataset("lighteval/med_mcqa", split="train")
     val_ds = load_dataset("lighteval/med_mcqa", split="validation")
 
-    def _map_example(example: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def _map_example(example: Dict[str, Any]) -> Dict[str, Any] | None:
         cop = example.get("cop", -1)
         if not isinstance(cop, int) or cop not in [1, 2, 3, 4]:
             return None
@@ -110,13 +117,23 @@ def load_environment(use_think: bool = False, system_prompt: Optional[str] = Non
         }
         mapped = med_mcqa(line)
         return mapped
-    
-    columns_to_remove = ['question', 'opa', 'opb', 'opc', 'opd', 'cop']
-    train_mapped = train_ds.map(_map_example,  remove_columns=columns_to_remove).filter(lambda x: x is not None)
-    val_mapped = val_ds.map(_map_example,  remove_columns=columns_to_remove).filter(lambda x: x is not None)
-    
-    system_prompt = system_prompt or (THINK_BOXED_SYSTEM_PROMPT if use_think else BOXED_SYSTEM_PROMPT)
-    parser = vf.ThinkParser(extract_boxed_answer) if use_think else vf.Parser(extract_boxed_answer)
+
+    columns_to_remove = ["question", "opa", "opb", "opc", "opd", "cop"]
+    train_mapped = train_ds.map(_map_example, remove_columns=columns_to_remove).filter(lambda x: x is not None)
+    val_mapped = val_ds.map(_map_example, remove_columns=columns_to_remove).filter(lambda x: x is not None)
+
+    # normalize answer_format
+    answer_format = AnswerFormat(answer_format) if isinstance(answer_format, str) else answer_format
+
+    if answer_format == AnswerFormat.XML:
+        system_prompt = system_prompt or (THINK_XML_SYSTEM_PROMPT if use_think else XML_SYSTEM_PROMPT)
+        parser_fields = ["think", "answer"] if use_think else ["answer"]
+        parser = vf.XMLParser(fields=parser_fields, answer_field="answer")
+    elif answer_format == AnswerFormat.BOXED:
+        system_prompt = system_prompt or (THINK_BOXED_SYSTEM_PROMPT if use_think else BOXED_SYSTEM_PROMPT)
+        parser = vf.ThinkParser(extract_boxed_answer) if use_think else vf.Parser(extract_boxed_answer)
+    else:
+        raise ValueError(f"Unsupported answer format: {answer_format=}")
 
     rubric = vf.Rubric(funcs=[exact_match_reward], weights=[1.0], parser=parser)
 
@@ -127,5 +144,5 @@ def load_environment(use_think: bool = False, system_prompt: Optional[str] = Non
         parser=parser,
         rubric=rubric,
     )
-    
+
     return env

--- a/environments/med_mcqa/pyproject.toml
+++ b/environments/med_mcqa/pyproject.toml
@@ -6,8 +6,12 @@ version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers>=0.1.5.post0",
+    "medarc_verifiers>=0.1.0",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+medarc_verifiers = { git = "https://github.com/MedARC-AI/med-lm-envs" }

--- a/environments/medbullets/pyproject.toml
+++ b/environments/medbullets/pyproject.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.3.post0",
+    "medarc_verifiers>=0.1.0",
 ]
 
 [tool.prime.environment]
@@ -19,3 +20,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build]
 include = ["medbullets.py"]
+
+[tool.uv.sources]
+medarc_verifiers = { git = "https://github.com/MedARC-AI/med-lm-envs" }

--- a/environments/medconceptsqa/pyproject.toml
+++ b/environments/medconceptsqa/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.5.post0",
     "datasets>=4.1.1",
+    "medarc_verifiers>=0.1.0",
 ]
 
 [tool.prime.environment]
@@ -17,3 +18,6 @@ visibility = "PUBLIC"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+medarc_verifiers = { git = "https://github.com/MedARC-AI/med-lm-envs" }

--- a/environments/medqa/pyproject.toml
+++ b/environments/medqa/pyproject.toml
@@ -16,6 +16,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = ["medqa.py"]
 
+[tool.uv.sources]
+medarc_verifiers = { git = "https://github.com/MedARC-AI/med-lm-envs" }
+
 [tool.prime.environment]
 # lets Prime/vf-eval know where the loader lives in a flat repo
 loader = "medqa:load_environment"

--- a/environments/medxpertqa/medxpertqa.py
+++ b/environments/medxpertqa/medxpertqa.py
@@ -2,12 +2,20 @@ import verifiers as vf
 from datasets import load_dataset
 from verifiers.utils.data_utils import extract_boxed_answer
 
+from medarc_verifiers.prompts import AnswerFormat
 
-def _get_system_prompt(use_think: bool) -> str:
-    think_system_prompt = "You are a helpful medical assistant. Think step-by-step inside <think>...</think> tags. Put your final answer within \\boxed{}."
-    no_think_system_prompt = (
-        "You are a helpful medical assistant. Think step-by-step and put your final answer within \\boxed{}."
-    )
+
+def _get_system_prompt(use_think: bool, answer_format: AnswerFormat) -> str:
+    if answer_format == AnswerFormat.BOXED:
+        think_system_prompt = "You are a helpful medical assistant. Think step-by-step inside <think>...</think> tags. Put your final answer within \\boxed{}."
+        no_think_system_prompt = (
+            "You are a helpful medical assistant. Think step-by-step and put your final answer within \\boxed{}."
+        )
+    elif answer_format == AnswerFormat.XML:
+        think_system_prompt = "You are a helpful medical assistant. Think step-by-step inside <think>...</think> tags. Put your final answer within <answer>...</answer> tags."
+        no_think_system_prompt = "You are a helpful medical assistant. Think step-by-step and put your final answer within <answer>...</answer> tags."
+    else:
+        raise ValueError(f"Unsupported answer format: {answer_format}")
     system_prompt = think_system_prompt if use_think else no_think_system_prompt
     return system_prompt
 
@@ -37,6 +45,7 @@ def _format_question_with_options(question_with_options: str, options) -> str:
 
 def load_environment(
     use_think: bool = False,
+    answer_format: AnswerFormat | str = AnswerFormat.XML,
 ) -> vf.Environment:
     """
     MedXpertQA environment using equality with the "label" column as the eval criterion.
@@ -60,24 +69,33 @@ def load_environment(
 
     mapped = test_dataset.map(_map).filter(lambda r: r is not None)
 
-    async def medxpertqa_reward_func(
-        completion: str,
-        answer: str,
-    ) -> float:
+    async def medxpertqa_reward_func(completion: str, answer: str) -> float:
         """
         Reward function for MedXpertQA environment.
         Compares the model response with the ground truth answer.
         Returns 1.0 if they match (case-insensitive), else 0.0.
         """
-        parser = vf.ThinkParser(extract_boxed_answer) if use_think else vf.Parser(extract_boxed_answer)
+
         final_answer = parser.parse_answer(completion).strip()
         if final_answer.lower() == answer.lower():
             return 1.0
         else:
             return 0.0
 
+    # normalize answer_format
+    answer_format = AnswerFormat(answer_format) if isinstance(answer_format, str) else answer_format
+    system_prompt = _get_system_prompt(use_think, answer_format)
+
+    if answer_format == AnswerFormat.XML:
+        parser_fields = ["think", "answer"] if use_think else ["answer"]
+        parser = vf.XMLParser(fields=parser_fields, answer_field="answer")
+    elif answer_format == AnswerFormat.BOXED:
+        parser = vf.ThinkParser(extract_boxed_answer) if use_think else vf.Parser(extract_boxed_answer)
+    else:
+        raise ValueError(f"Unsupported answer format: {answer_format=}")
+
     rubric = vf.Rubric(funcs=[medxpertqa_reward_func], weights=[1.0])
 
-    vf_env = vf.SingleTurnEnv(eval_dataset=mapped, system_prompt=_get_system_prompt(use_think), rubric=rubric)
+    vf_env = vf.SingleTurnEnv(eval_dataset=mapped, system_prompt=system_prompt, rubric=rubric, parser=parser)
 
     return vf_env

--- a/environments/medxpertqa/pyproject.toml
+++ b/environments/medxpertqa/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.4",
     "datasets>=4.0.0",
+    "medarc_verifiers>=0.1.0",
 ]
 
 [build-system]
@@ -16,8 +17,11 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = ["medxpertqa.py"]
 
+[tool.uv.sources]
+medarc_verifiers = { git = "https://github.com/MedARC-AI/med-lm-envs" }
+
 [tool.prime.environment]
 # lets Prime/vf-eval know where the loader lives in a flat repo
-loader = "c:load_environment"
+loader = "medxpertqa:load_environment"
 display_name = "MedXpertQA"
 visibility = "PUBLIC"

--- a/environments/metamedqa/metamedqa.py
+++ b/environments/metamedqa/metamedqa.py
@@ -1,7 +1,8 @@
-from __future__ import annotations
-from typing import Dict, Optional, Any
-from datasets import load_dataset
+from typing import Any, Dict, Optional
+
 import verifiers as vf
+from datasets import load_dataset
+
 
 def _get_text_from_completion(completion: Any) -> str:
     if isinstance(completion, str):
@@ -13,12 +14,14 @@ def _get_text_from_completion(completion: Any) -> str:
         return str(last)
     return str(completion)
 
+
 def _first_letter(text: str) -> Optional[str]:
     t = (text or "").upper()
     for ch in t:
         if "A" <= ch <= "Z":
             return ch
     return None
+
 
 def _build_prompt(question: str, options: Dict[str, str]) -> str:
     opts = "\n".join(f"{k}. {v}" for k, v in options.items())
@@ -30,9 +33,10 @@ def _build_prompt(question: str, options: Dict[str, str]) -> str:
         f"Answer with ONLY the letter ({letters})."
     )
 
+
 def load_environment(split: str = "test") -> vf.Environment:
     """
-    MetaMedQA multiple-choice accuracy eval 
+    MetaMedQA multiple-choice accuracy eval
     - Loads HF 'maximegmd/MetaMedQA'
     - Builds a prompt per item
     - Scores accuracy by comparing the first A–Z from the model to the gold letter
@@ -41,8 +45,8 @@ def load_environment(split: str = "test") -> vf.Environment:
 
     def _map(ex):
         q: str = ex["question"]
-        options: Dict[str, str] = ex["options"]     
-        gold_text: str = ex["answer"]               
+        options: Dict[str, str] = ex["options"]
+        gold_text: str = ex["answer"]
 
         gold_letter = None
         for k, v in options.items():
@@ -50,11 +54,11 @@ def load_environment(split: str = "test") -> vf.Environment:
                 gold_letter = k
                 break
         if gold_letter is None:
-            return None 
+            return None
 
         return {
             "question": _build_prompt(q, options),
-            "answer": gold_letter,   
+            "answer": gold_letter,
         }
 
     mapped = ds.map(_map, remove_columns=ds.column_names).filter(lambda r: r is not None)

--- a/environments/pubmedqa/pubmedqa.py
+++ b/environments/pubmedqa/pubmedqa.py
@@ -1,39 +1,39 @@
-import os
 import json
-from datasets import load_dataset
-import verifiers as vf
+import os
 
-SYSTEM_PROMPT_THINK=vf.utils.data_utils.THINK_BOXED_SYSTEM_PROMPT
-SYSTEM_PROMPT_NOTHINK = vf.utils.data_utils.BOXED_SYSTEM_PROMPT
+import verifiers as vf
+from datasets import load_dataset
+from medarc_verifiers.prompts import THINK_XML_SYSTEM_PROMPT, XML_SYSTEM_PROMPT, AnswerFormat
+from verifiers.utils.data_utils import BOXED_SYSTEM_PROMPT, THINK_BOXED_SYSTEM_PROMPT, extract_boxed_answer
 
 SINGLE_PROMPT_TEMPLATE = r"""Answer A for yes, B for no or C for maybe.\n\nContext: {abstract_as_context}\n\nQuestion: {question}\nAnswer: """
+
 
 def map_row_to_mcq_prompt(row):
     """Map dataset format for PubMedQA samples"""
 
-    # each example is a row of the HF dataset with keys: 
+    # each example is a row of the HF dataset with keys:
     # ['pubid', 'question', 'context', 'long_answer', 'final_decision']
-    question_text = row.get('question')
+    question_text = row.get("question")
 
-    context_dict = row.get('context')
-    labels = context_dict.get('labels') # list of the abstract subsection titles
-    contexts = context_dict.get('contexts') # a list of the subsections contents
-    
+    context_dict = row.get("context")
+    labels = context_dict.get("labels")  # list of the abstract subsection titles
+    contexts = context_dict.get("contexts")  # a list of the subsections contents
+
     # a string which is either "yes", "no" or "maybe"
-    final_decision = row.get('final_decision', '').lower() 
-    choices_map = {"yes": "A", "no": "B", "maybe": "C"} 
+    final_decision = row.get("final_decision", "").lower()
+    choices_map = {"yes": "A", "no": "B", "maybe": "C"}
     correct_answer_letter = choices_map[final_decision]
-    
+
     # Zip them together and format as label[0]: contexts[0]
     formatted_contexts = []
     for label, context in zip(labels, contexts):
         formatted_contexts.append(f"{label}. {context}")
-    context_text = '\n'.join(formatted_contexts)
+    context_text = "\n".join(formatted_contexts)
 
     # see EXAMPLE_COMPLETE_PROMPT
-    complete_prompt = SINGLE_PROMPT_TEMPLATE.format(abstract_as_context=context_text,
-            question=question_text)
-        
+    complete_prompt = SINGLE_PROMPT_TEMPLATE.format(abstract_as_context=context_text, question=question_text)
+
     # required fields: question (for the prompt), and answer (for the scoring)
     return {
         "question": complete_prompt,
@@ -49,64 +49,68 @@ def classification_reward_func(prompt, completion, answer, state, **kwargs) -> f
     """
 
     # completition is a chat response, like: {'role': 'assistant', 'content': 'ANSWER: A'}]
-    completion=completion[0]["content"]
-    
-    parsed_completion = kwargs["parser"].parse(completion);
+    completion = completion[0]["content"]
+
+    parsed_completion = kwargs["parser"].parse(completion)
     predicted_letter = parsed_completion.strip().rstrip(".")
 
     if predicted_letter is None:
         return 0.0  # Incorrect if no valid answer found
-    
+
     return 1.0 if predicted_letter == answer else 0.0
 
 
-def load_environment(use_think: bool = False) -> vf.Environment:
+def load_environment(use_think: bool = False, answer_format: AnswerFormat | str = AnswerFormat.XML) -> vf.Environment:
     """
     PubMedQA environment using classification-based evaluation.
-    
+
     This environment loads the PubMedQA dataset and uses exact match scoring
     for yes/no/maybe classification tasks.
     """
-    
+
     # Both subsets only have a 'train' split
     DATASET_PATH = "qiaojin/PubMedQA"
     dataset_train = load_dataset(DATASET_PATH, name="pqa_artificial", split="train")
     dataset_test = load_dataset(DATASET_PATH, name="pqa_labeled", split="train")
 
-    # Read in the predefined IDs in the test split taken from 
+    # Read in the predefined IDs in the test split taken from
     # https://github.com/pubmedqa/pubmedqa/blob/master/data/test_ground_truth.json
     here = os.path.dirname(__file__)
     file_path = os.path.join(here, "data", "test_ground_truth.json")
     with open(file_path) as f:
         test_ids = json.load(f)
-    
+
     # reducing the 1000k annotated to the 500 human annotated
-    dataset_test = dataset_test.filter(
-        lambda sample: str(sample["pubid"]) in test_ids
-    )
-    
+    dataset_test = dataset_test.filter(lambda sample: str(sample["pubid"]) in test_ids)
+
     mapped_dataset_train = dataset_train.map(map_row_to_mcq_prompt, load_from_cache_file=False, keep_in_memory=True)
     mapped_dataset_test = dataset_test.map(map_row_to_mcq_prompt, load_from_cache_file=False, keep_in_memory=True)
 
-    sys_prompt=SYSTEM_PROMPT_NOTHINK
-    parser = vf.parsers.parser.Parser(extract_fn = vf.extract_boxed_answer) 
+    # normalize answer_format
+    answer_format = AnswerFormat(answer_format) if isinstance(answer_format, str) else answer_format
 
-    if use_think:
-        sys_prompt=SYSTEM_PROMPT_THINK
-        parser = vf.parsers.think_parser.ThinkParser(extract_fn = vf.extract_boxed_answer)
+    if answer_format == AnswerFormat.XML:
+        parser_fields = ["think", "answer"] if use_think else ["answer"]
+        parser = vf.XMLParser(fields=parser_fields, answer_field="answer")
+        system_prompt = THINK_XML_SYSTEM_PROMPT if use_think else XML_SYSTEM_PROMPT
+    elif answer_format == AnswerFormat.BOXED:
+        parser = (
+            vf.ThinkParser(extract_fn=extract_boxed_answer) if use_think else vf.Parser(extract_fn=extract_boxed_answer)
+        )
+        system_prompt = THINK_BOXED_SYSTEM_PROMPT if use_think else BOXED_SYSTEM_PROMPT
+    else:
+        raise ValueError(f"Unsupported answer format: {answer_format=}")
 
     # parses the reponse using parser and calculates rewards
-    rubric = vf.Rubric(
-        funcs=[classification_reward_func], weights=[1.0], parser= parser
-    )
+    rubric = vf.Rubric(funcs=[classification_reward_func], weights=[1.0], parser=parser)
 
     # Create the environment
     vf_env = vf.SingleTurnEnv(
         dataset=mapped_dataset_train,
         eval_dataset=mapped_dataset_test,
-        system_prompt=sys_prompt,
-        rubric=rubric, # if a rubric is given, it needs to manually call the parser
-        parser=parser, # needs to be same parser as given to rubric, otherwise raises a warning
+        system_prompt=system_prompt,
+        rubric=rubric,  # if a rubric is given, it needs to manually call the parser
+        parser=parser,  # needs to be same parser as given to rubric, otherwise raises a warning
     )
 
     return vf_env

--- a/environments/pubmedqa/pyproject.toml
+++ b/environments/pubmedqa/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.3.post0",
     "datasets>= 4.0.0"
+    "medarc_verifiers>=0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -21,3 +22,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build]
 include = ["pubmedqa.py"]
+
+[tool.uv.sources]
+medarc_verifiers = { git = "https://github.com/MedARC-AI/med-lm-envs" }

--- a/medarc_verifiers/prompts.py
+++ b/medarc_verifiers/prompts.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+THINK_XML_SYSTEM_PROMPT = "Think step-by-step inside <think>...</think> tags. Then, give your final answer inside <answer>...</answer> XML tags."
+
+XML_SYSTEM_PROMPT = "Please reason step by step, then give your final answer within <answer>...</answer> XML tags."
+
+
+class AnswerFormat(str, Enum):
+    BOXED = "boxed"
+    JSON = "json"
+    XML = "xml"

--- a/medarc_verifiers/utils/cli_env_args.py
+++ b/medarc_verifiers/utils/cli_env_args.py
@@ -201,6 +201,13 @@ def _infer_argparse_spec(annotation: Any, default: Any) -> ArgSpec:
         return ArgSpec("unsupported", None, None, None, False, None, reason)
 
     if _is_union(normalized):
+        union_args = get_args(normalized)
+        enum_args = [arg for arg in union_args if _is_enum(arg)]
+        non_enum_args = [arg for arg in union_args if not _is_enum(arg)]
+        if len(enum_args) == 1 and all(arg is str for arg in non_enum_args):
+            enum_cls = enum_args[0]
+            choices = tuple(member.value for member in enum_cls)
+            return ArgSpec("enum", None, choices, None, False, None, None)
         reason = "non-optional union unsupported"
         return ArgSpec("unsupported", None, None, None, False, None, reason)
 

--- a/tests/test_cli_env_args.py
+++ b/tests/test_cli_env_args.py
@@ -1,3 +1,4 @@
+import enum
 import sys
 import types
 from collections.abc import Callable
@@ -99,6 +100,22 @@ def test_unsupported_dict_and_union(module_registry: list[str]) -> None:
 
     choice = params[1]
     assert choice.unsupported_reason == "non-optional union unsupported"
+
+
+def test_enum_str_union(module_registry: list[str]) -> None:
+    class AnswerFormat(enum.Enum):
+        XML = "xml"
+        BOXED = "boxed"
+
+    def load_environment(answer_format: AnswerFormat | str = AnswerFormat.XML) -> None:
+        """Loader mixing enum and str."""
+
+    _register_env("test_env_enum_union", load_environment, module_registry)
+    params = gather_env_cli_metadata("test_env_enum_union")
+    answer_format = params[0]
+    assert answer_format.choices == ("xml", "boxed")
+    assert answer_format.unsupported_reason is None
+    assert answer_format.default == AnswerFormat.XML
 
 
 def test_missing_annotation_uses_default_type(module_registry: list[str]) -> None:


### PR DESCRIPTION
Add support for xml answers and fix a few env defaults.

The following envs were updated to use xml formatted answers after spot checking model performance vs boxed answers:
- med_mcqa
- medconceptsqa
- medqa
- medxpertqa
- pubmedqa