### PR TITLE
Fix Pubmedqa Erroring out

### DIFF
--- a/environments/pubmedqa/pyproject.toml
+++ b/environments/pubmedqa/pyproject.toml
@@ -24,4 +24,4 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-include = ["pubmedqa.py"]
+include = ["pubmedqa.py", "data/"]


### PR DESCRIPTION
Summary
Include data/ directory in pubmedqa package build so test_ground_truth.json is copied into site-packages on non-editable installs

Reason for fix:
When installing this environment, it fails with:
`FileNotFoundError: [Errno 2] No such file or directory: 'mbeavers/Projects/med-lm-train/.venv/lib/python3.12/site-packages/data/test_ground_truth.json'`

Test plan
 Install non-editably and verify the path resolves(editable install works, probably reason why it was missed): 
`uv pip install environments/pubmedqa/`;
```
uv run python -c "import pubmedqa, os;
here = os.path.dirname(pubmedqa.__file__);
print(os.path.exists(os.path.join(here, 'data', 'test_ground_truth.json')))"
```