### PR TITLE
medcalcbench not referencing the directory, so fails on import

### DIFF
--- a/environments/medcalc_bench/pyproject.toml
+++ b/environments/medcalc_bench/pyproject.toml
@@ -19,7 +19,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-include = ["medcalc_bench.py"]
+include = ["medcalc_bench"]
 
 
 [tool.prime.environment]


### PR DESCRIPTION
Fix medcalc-bench hatch build config to include package directory

The [tool.hatch.build] section in environments/medcalc_bench/pyproject.toml referenced medcalc_bench.py (a flat file that no longer exists) instead of the medcalc_bench package directory. This caused hatchling to omit the package's __init__.py from the build, so load_environment was never importable and the environment failed to load with:


RuntimeError: Failed to load environment 'medarc/medcalc-bench': Module 'medcalc_bench' does not have a 'load_environment' function.
Changed include = ["medcalc_bench.py"] → include = ["medcalc_bench"] to match the actual package directory, consistent with how other environments like medagentbenchv2 are configured.

Tested with:
```
import medcalc_bench as mb
mb.load_environment
```
return <function load_environment at 0x7fb4704b7d80>, before fails with the function not available. 